### PR TITLE
Use more specific jQuery selectors

### DIFF
--- a/static/js/profiler.js
+++ b/static/js/profiler.js
@@ -106,10 +106,10 @@ var GaeMiniProfiler = {
 
     toggleSection: function(elLink, selector) {
 
-        var fWasVisible = $(selector).is(":visible");
+        var fWasVisible = $(".g-m-p " + selector).is(":visible");
 
-        $(".expand").removeClass("expanded");
-        $(".details:visible").slideUp(50)
+        $(".g-m-p .expand").removeClass("expanded");
+        $(".g-m-p .details:visible").slideUp(50);
 
         if (!fWasVisible) {
             $(elLink).parents(".expand").addClass("expanded");


### PR DESCRIPTION
The previous behavior caused every (visible) element in the document with the class name 'details' to
be slided up whenever a menu item in the profiler menu was selected.
