### PR TITLE
PEP8 compliance

### DIFF
--- a/config.py
+++ b/config.py
@@ -9,6 +9,7 @@ enabled_profiler_emails = [
 
 enable_profiler_admins = True
 
+
 # Customize should_profile to return true whenever a request should be profiled.
 # This function will be run once per request, so make sure its contents are fast.
 def should_profile(environ):

--- a/main.py
+++ b/main.py
@@ -11,6 +11,7 @@ application = webapp.WSGIApplication([
 
 template.register_template_library('gae_mini_profiler.templatetags')
 
+
 def main():
     run_wsgi_app(application)
 

--- a/templatetags.py
+++ b/templatetags.py
@@ -1,4 +1,3 @@
-import logging
 import simplejson
 import os
 
@@ -9,8 +8,9 @@ from gae_mini_profiler import profiler
 
 register = webapp.template.create_template_register()
 
+
 @register.simple_tag
-def profiler_includes_request_id(request_id, show_immediately = False):
+def profiler_includes_request_id(request_id, show_immediately=False):
     if not request_id:
         return ""
 
@@ -22,8 +22,7 @@ def profiler_includes_request_id(request_id, show_immediately = False):
         "show_immediately_js": simplejson.dumps(show_immediately),
     })
 
+
 @register.simple_tag
 def profiler_includes():
     return profiler_includes_request_id(profiler.request_id)
-
-


### PR DESCRIPTION
Some un-PEP8tish code slipped into the code.

Internally we check for such rings automatically and rigurously to minimize whitespace changes and other stuff which other wises clutters our change sets.

This patch addresses concerns of:

```
$ pyflakes .
$ pep8 -r --ignore=E501 .
```

No changes in functionality.
