### PR TITLE
Python 2.7 support

### DIFF
--- a/profiler.py
+++ b/profiler.py
@@ -2,7 +2,10 @@ import datetime
 import os
 import pickle
 import re
-import simplejson
+try:
+    import json
+except ImportError:
+    import simplejson as json
 import StringIO
 from types import GeneratorType
 import zlib
@@ -65,7 +68,7 @@ class RequestStatsHandler(RequestHandler):
                     request_stats.disabled = True
                     request_stats.store()
 
-        self.response.out.write(simplejson.dumps(list_request_stats))
+        self.response.out.write(json.dumps(list_request_stats))
 
 
 class RequestStats(object):

--- a/templatetags.py
+++ b/templatetags.py
@@ -1,4 +1,7 @@
-import simplejson
+try:
+    import json
+except ImportError:
+    import simplejson as json
 import os
 
 from google.appengine.ext.webapp import template
@@ -19,7 +22,7 @@ def profiler_includes_request_id(request_id, show_immediately=False):
         "request_id": request_id,
         "js_path": "/gae_mini_profiler/static/js/profiler.js",
         "css_path": "/gae_mini_profiler/static/css/profiler.css",
-        "show_immediately_js": simplejson.dumps(show_immediately),
+        "show_immediately_js": json.dumps(show_immediately),
     })
 
 


### PR DESCRIPTION
Use json if available, fall back to simplejson. (simplejson is not available on gae with python27.)
