### PR TITLE
display corner even with toolbars and stuff

### DIFF
--- a/static/css/profiler.css
+++ b/static/css/profiler.css
@@ -64,7 +64,7 @@
     -moz-border-radius-bottomright: 12px;
     border-bottom-right-radius: 12px;
 
-    z-index: 1000;
+    z-index: 10001;
 }
 
 .g-m-p .title {


### PR DESCRIPTION
Many CSS frameworks use z-index extensively for toolbars
and the like. 1000 seems to be the "normal" z-index for this stuff
thus hiding the profiler corner. Unless you know
what you are looking for this is very hard to debug.

This patch sets a unreasonable high z-index
(10001) in the hope to be rendered above everything else.

In my case it was Twitter-Bootstrap which is placing the toolbar at z-index: 1001
