### PR TITLE
Use public call_stack_list() for python27

### DIFF
--- a/profiler.py
+++ b/profiler.py
@@ -241,7 +241,7 @@ class RequestStats(object):
                 service_totals_dict[service_prefix]["total_time"] += trace.duration_milliseconds()
 
                 stack_frames_desc = []
-                for frame in trace.call_stack_:
+                for frame in trace.call_stack_list():
                     stack_frames_desc.append("%s:%s %s" %
                             (RequestStats.short_rpc_file_fmt(frame.class_or_file_name()),
                                 frame.line_number(),


### PR DESCRIPTION
The python27 runtime doesn't have the call_stack_ member that the python
runtime did. This patch uses a more public-looking function instead.
