### PR TITLE
Step 5 of "Getting Started" os not working correctly.

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,10 +74,10 @@ You can play around with one of GAE's sample applications with gae_mini_profiler
     If you use the static inclusion you probably should use your template engine to include the code only
 for admins or other profiling-prone users.
 
-5. You're all set! Just choose the users for whom you'd like to enable profiling by putting the respective E-Mail addresses in `appengine_config.py`:
+5. You're all set! Just choose the users for whom you'd like to enable profiling by putting the respective E-Mail addresses in `gae_mini_profiler/config.py`:
 
-            gae_mini_profiler_ENABLED_PROFILER_EMAILS = ['user1@example.com',
-                                                         'user2@example.com']
+            enabled_profiler_emails = ['user1@example.com',
+                                       'user2@example.com']
 
 For more sophisticated choice of what to profile check `gae_mini_profiler/config.py`.
 


### PR DESCRIPTION
gae_mini_profiler_ENABLED_PROFILER_EMAILS is never used anywhere.
