### PR TITLE
Protocol-relative URL and jQuery updated to 1.9.1

### DIFF
--- a/templates/shared.html
+++ b/templates/shared.html
@@ -1,6 +1,6 @@
 <html>
     <head>
-        <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/1.6.1/jquery.min.js"></script>
+        <script type="text/javascript" src="//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
     </head>
     <body class="g-m-p-shared">
         <div class="shared-teaser-container">


### PR DESCRIPTION
Updated the URL to protocol-relative in the shared.html and also pointing to the latest (1.9.1) version of jQuery
