### PR TITLE
Fix two small issues

### DIFF
--- a/profiler.py
+++ b/profiler.py
@@ -31,7 +31,7 @@ import pickle
 import config
 import util
 
-dev_server = os.environ["SERVER_SOFTWARE"].startswith("Devel")
+dev_server = os.environ.get("SERVER_SOFTWARE", "").startswith("Devel")
 
 
 class CurrentRequestId(object):

--- a/templatetags.py
+++ b/templatetags.py
@@ -4,6 +4,7 @@ try:
 except ImportError:
     import simplejson as json
 
+import config
 import profiler
 
 
@@ -22,4 +23,6 @@ def profiler_includes_request_id(request_id, show_immediately=False):
 
 
 def profiler_includes():
+    if not config.should_profile():
+        return ''
     return profiler_includes_request_id(profiler.CurrentRequestId.get())


### PR DESCRIPTION
Fixes two small issues:
- os.environ["SERVER_SOFTWARE"] blows up when running unser gaenose (it apparently doesn't set the appropriate environment variable)
- profile tags should not be output to the page if profiling is disabled for it, since we don't have a request ID anyways
