### PR TITLE
Make default profile mode configurable from appengine_config.py

### DIFF
--- a/config.py
+++ b/config.py
@@ -16,25 +16,89 @@ from google.appengine.api import lib_config
 #           from google.appengine.api import users
 #           return users.is_current_user_admin()
 
-def _should_profile_production_default():
-    """Default to disabling in production if this function isn't overridden.
 
-    Can be overridden in appengine_config.py"""
-    return False
+class Mode(object):
+    """Possible profiler modes.
 
-def _should_profile_development_default():
-    """Default to enabling in development if this function isn't overridden.
+    TODO(kamens): switch this from an enum to a more sensible bitmask or other
+    alternative that supports multiple settings without an exploding number of
+    enums.
 
-    Can be overridden in appengine_config.py"""
-    return True
+    TODO(kamens): when this is changed from an enum to a bitmask or other more
+    sensible object with multiple properties, we should pass a Mode object
+    around the rest of this code instead of using a simple string that this
+    static class is forced to examine (e.g. if self.mode.is_rpc_enabled()).
+    """
+
+    SIMPLE = "simple"  # Simple start/end timing for the request as a whole
+    CPU_INSTRUMENTED = "instrumented"  # Profile all function calls
+    CPU_SAMPLING = "sampling"  # Sample call stacks
+    RPC_ONLY = "rpc"  # Profile all RPC calls
+    RPC_AND_CPU_INSTRUMENTED = "rpc_instrumented" # RPCs and all fxn calls
+    RPC_AND_CPU_SAMPLING = "rpc_sampling" # RPCs and sample call stacks
+
+    @staticmethod
+    def is_rpc_enabled(mode):
+        return mode in [
+                Mode.RPC_ONLY,
+                Mode.RPC_AND_CPU_INSTRUMENTED,
+                Mode.RPC_AND_CPU_SAMPLING];
+
+    @staticmethod
+    def is_sampling_enabled(mode):
+        return mode in [
+                Mode.CPU_SAMPLING,
+                Mode.RPC_AND_CPU_SAMPLING];
+
+    @staticmethod
+    def is_instrumented_enabled(mode):
+        return mode in [
+                Mode.CPU_INSTRUMENTED,
+                Mode.RPC_AND_CPU_INSTRUMENTED];
+
 
 _config = lib_config.register("gae_mini_profiler", {
-    "should_profile_production": _should_profile_production_default,
-    "should_profile_development": _should_profile_development_default})
+    # Default to disabling in production if this function isn't overridden.
+    "should_profile_production": lambda: False,
+    # Default to enabling in development if this function isn't overridden.
+    "should_profile_development": lambda: True})
+
+
+_mode = lib_config.register("gae_mini_profiler", {
+    "get_default_mode_production": lambda: Mode.RPC_AND_CPU_SAMPLING,
+    "get_default_mode_development": lambda: Mode.RPC_AND_CPU_INSTRUMENTED})
+
+
+_DEVELOPMENT_SERVER = os.environ.get("SERVER_SOFTWARE", "").startswith("Devel")
+
 
 def should_profile():
     """Returns true if the current request should be profiles."""
-    if os.environ["SERVER_SOFTWARE"].startswith("Devel"):
+    if _DEVELOPMENT_SERVER:
         return _config.should_profile_development()
     else:
         return _config.should_profile_production()
+
+
+def get_mode(environ, cookies):
+    """Returns the profiling mode in by current request's headers & cookies.
+
+    If not set explicitly, calls gae_mini_profiler_get_default_mode_development / production"""
+    if "HTTP_G_M_P_MODE" in environ:
+        mode = environ["HTTP_G_M_P_MODE"]
+    else:
+        mode = cookies.get_cookie_value("g-m-p-mode")
+
+    if (mode in [
+            Mode.SIMPLE,
+            Mode.CPU_INSTRUMENTED,
+            Mode.CPU_SAMPLING,
+            Mode.RPC_ONLY,
+            Mode.RPC_AND_CPU_INSTRUMENTED,
+            Mode.RPC_AND_CPU_SAMPLING]):
+        return mode
+
+    if _DEVELOPMENT_SERVER:
+        return _mode.get_default_mode_development()
+    else:
+        return _mode.get_default_mode_production()


### PR DESCRIPTION
Example use case: we want the default to be instrumentation + RPC on dev server and RPC only in production, unless the current user changes it.