### PR TITLE
Allow hiding mini profiler (for demos, etc)

### DIFF
--- a/static/js/profiler.js
+++ b/static/js/profiler.js
@@ -15,6 +15,11 @@ var GaeMiniProfiler = {
     },
 
     init: function(requestId, fShowImmediately) {
+        var hide = +$.cookiePlugin("g-m-p-hide");
+        if (hide && !fShowImmediately) {
+            return;
+        }
+
         // Fetch profile results for any ajax calls
         // (see http://code.google.com/p/mvc-mini-profiler/source/browse/MvcMiniProfiler/UI/Includes.js)
         $(document).ajaxComplete(function (e, xhr, settings) {


### PR DESCRIPTION
No interface for this yet.

@kamens

Test Plan:
Ran `document.cookie = 'g-m-p-hide=1';` in the console and the profiler disappeared on the next page load.
