### PR TITLE
Add import guard and installation instructions on line profiler for non OSX users

### DIFF
--- a/linebyline_profiler.py
+++ b/linebyline_profiler.py
@@ -19,8 +19,11 @@ if _is_dev_server:
     # white-list the line_profiler C extension
     sys.meta_path[3]._enabled_regexes.append(re.compile(r'.*line_profiler.*'))
 
-    import line_profiler
-    assert line_profiler  # Silence pyflakes
+    try:
+        import line_profiler
+        assert line_profiler  # silence pyflakes
+    except ImportError:
+        line_profiler = None
 else:
     line_profiler = None
 
@@ -139,8 +142,20 @@ class Profile(object):
                 self.line_prof.add_function(f)
 
     def results(self):
+        err_msg = ""
+
+        if not _is_dev_server:
+            err_msg = "The line-by-line profiler can only be used in dev."
+        elif line_profiler is None:
+            err_msg = (
+                "Could not load the line_profiler module.<br><br>"
+                "Try installing the C extension like so:<br>"
+                "&nbsp;&nbsp;sudo pip install line_profiler==1.0b3<br>"
+                "&nbsp;&nbsp;(cd / && cp `python -c 'import _line_profiler; print _line_profiler.__file__'` %s)" % os.path.dirname(__file__)
+            )
+
         res = {
-            "is_dev_server": _is_dev_server,
+            "err_msg": err_msg,
             "num_functions_marked": self.num_functions_marked,
             "calls": []
         }

--- a/static/js/template.tmpl
+++ b/static/js/template.tmpl
@@ -175,9 +175,9 @@
 
             {{/if}}
             {{if GaeMiniProfiler.isLineByLineEnabled(mode)}}
-            {{if !profiler_results.is_dev_server}}
+            {{if profiler_results.err_msg}}
             <span class="warn">
-                The line-by-line profiler can only be used in development.
+                {{html profiler_results.err_msg}}
             </span>
             {{else profiler_results.num_functions_marked == 0}}
             <span>


### PR DESCRIPTION
## Test Plan:

On OSX, load up a page with the profiler turned on and change the profiling mode to line-by-line.
You should see usage instructions as normal.

Now replace the `_line_profiler.so` file with a garbage file, e.g. like this:

```
echo 'garbage' > _line_profiler.so
```

This is to emulate wrong architecture trying to be loaded.
Reload the page in browser, and you should be presented with a message similar to this once you expand the profiling results:

```
Could not load line_profiler c extension.

Try installing it like so:
  sudo pip install line_profiler==1.0b3
  (cd / && cp `python -c 'import _line_profiler; print _line_profiler.__file__'` /Users/jlfwong/khan/webapp/third_party/gae_mini_profiler)
```

Except with the paths customized for your installation.
Run the commands, reload the page, and you should see usage instructions again.

Unfortunately this dirties the working copy by modifying the checked in `_line_profiler`, but I can't think of a sensible way of getting around that without making this more work for the OS X devs (which is most of Khan).
## Notes:

My original plan of trying to import it from several different sources was canned because apparently the import name you give when importing a c extension has to match some internally compiled function. For instance:

```
$ python -c 'import _line_profiler; print _line_profiler.__file__'
_line_profiler.so
$ mv _line_profiler.so _line_profiler_osx.so
$ python -c 'import _line_profiler_osx; print _line_profiler_osx.__file__'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
ImportError: dynamic module does not define init function (init_line_profiler_osx)
```

I tried to get around this using

```
import imp
fileobj, path, desc = imp.find_module('_line_profiler_osx')
imp.load_module('_line_profiler', fileobj, path, desc)
```

which works when I tried it in the REPL, but not when I tried using it in `line_profiler.py`. I suspect this is GAE sandboxing in action.

@cdman @spicyj @kamens 
